### PR TITLE
Recognize hash variable syntax

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -69,6 +69,7 @@ syn region  puppetFunction      start="^\s*\(defined\|file\|fqdn_rand\|generate\
 
 syn match   puppetVariable      "$[a-zA-Z0-9_:]\+" contains=@NoSpell
 syn match   puppetVariable      "${[a-zA-Z0-9_:]\+}" contains=@NoSpell
+syn match   puppetVariable      "${[a-zA-Z0-9_:]\+\[\'[a-z]\+\'\]}" contains=@NoSpell
 
 " match anything between simple/double quotes.
 " don't match variables if preceded by a backslash.

--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -69,7 +69,7 @@ syn region  puppetFunction      start="^\s*\(defined\|file\|fqdn_rand\|generate\
 
 syn match   puppetVariable      "$[a-zA-Z0-9_:]\+" contains=@NoSpell
 syn match   puppetVariable      "${[a-zA-Z0-9_:]\+}" contains=@NoSpell
-syn match   puppetVariable      "${[a-zA-Z0-9_:]\+\[\'[a-z]\+\'\]}" contains=@NoSpell
+syn match   puppetVariable      "${[a-zA-Z0-9_:]\+\(\[\'[a-zA-Z0-9_]\+\'\]\)\+}" contains=@NoSpell
 
 " match anything between simple/double quotes.
 " don't match variables if preceded by a backslash.


### PR DESCRIPTION
This adds syntax highlight support for variables of the type `${facts['fqdn']}`.
This fixes voxpupuli/vim-puppet#6.